### PR TITLE
Include payload in error event

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,7 +42,7 @@ module.exports = class Router extends EventEmitter {
         this.app.get('/test/bundle/:file', this.getTestFileCallback());
 
         this.app.use((error, req, res, next) => {
-            this.emit('request error', res.locals.track, req.method, req.path, error);
+            this.emit('request error', res.locals.track, req.method, req.path, res.locals.payload, error);
             next(error);
         });
 


### PR DESCRIPTION
Should we just include the whole `res.locals`?