### PR TITLE
Wrap original error on 'file not saved'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -135,8 +135,8 @@ module.exports = class Router extends EventEmitter {
                 next();
             });
 
-            fileWriteStream.on('file not saved', () => {
-                next(boom.badRequest('Generated file could not be saved'));
+            fileWriteStream.on('file not saved', (error) => {
+                next(boom.wrap(error, 400, 'Generated file could not be saved'));
             });
 
             fileWriteStream.on('error', (error) => {


### PR DESCRIPTION
Makes it match `postFeedPersistCallback`'s handling of the same error