### PR TITLE
Upgrade deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,9 +270,9 @@
       }
     },
     "boom": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-5.1.0.tgz",
-      "integrity": "sha1-Awj6jpJM1tQtnDv0iDvcmPDnHfg=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+      "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
       "requires": {
         "hoek": "4.2.0"
       }
@@ -445,35 +445,23 @@
       }
     },
     "compression": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
-      "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
       "requires": {
         "accepts": "1.3.4",
-        "bytes": "2.3.0",
+        "bytes": "2.5.0",
         "compressible": "2.0.11",
-        "debug": "2.2.0",
+        "debug": "2.6.8",
         "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
         "vary": "1.1.1"
       },
       "dependencies": {
         "bytes": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-          "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA="
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+          "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
         }
       }
     },
@@ -550,9 +538,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.3.tgz",
-      "integrity": "sha1-TPeOHSMymnSWsvwiJbd8pbteuAI=",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
       "requires": {
         "object-assign": "4.1.1",
         "vary": "1.1.1"
@@ -884,9 +872,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -894,8 +882,8 @@
         "content-type": "1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.0",
@@ -907,10 +895,10 @@
         "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "1.1.5",
-        "qs": "6.4.0",
+        "qs": "6.5.0",
         "range-parser": "1.2.0",
-        "send": "0.15.3",
-        "serve-static": "1.12.3",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
@@ -918,13 +906,10 @@
         "vary": "1.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         }
       }
     },
@@ -3491,9 +3476,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -3659,12 +3644,12 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "requires": {
-        "debug": "2.6.7",
-        "depd": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -3678,25 +3663,22 @@
         "statuses": "1.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         }
       }
     },
     "serve-static": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.1",
-        "send": "0.15.3"
+        "send": "0.15.4"
       }
     },
     "setprototypeof": {
@@ -3910,9 +3892,9 @@
       }
     },
     "tap": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-10.7.0.tgz",
-      "integrity": "sha512-rIKS3HvtA+/6weSQW8zgA8bKHt//Srucp6P1pugHUVZ+SexZcPw6N3n8LCAoH2okp/js+honhxwBl7bomZ9+7w==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-10.7.2.tgz",
+      "integrity": "sha512-N7z+tqiEvMT+wd79c17FqtL5h/AOObtffVTSfWUogrmFkJ37OfHLl8WuQYpd/YiOzS3k74acPF1F9bX0LzHOKw==",
       "dev": true,
       "requires": {
         "bind-obj-methods": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
     "asset-pipe-js-reader": "1.0.0-beta.9",
     "asset-pipe-sink-fs": "1.0.0-beta.9",
     "asset-pipe-sink-mem": "1.0.0-beta.5",
-    "body": "5.1.0",
-    "bole": "3.0.2",
-    "boom": "5.2.0",
-    "compression": "1.7.0",
-    "convict": "4.0.0",
-    "cors": "2.8.4",
-    "express": "4.15.4",
-    "joi": "10.6.0",
+    "body": "^5.1.0",
+    "bole": "^3.0.2",
+    "boom": "^5.2.0",
+    "compression": "^1.7.0",
+    "convict": "^4.0.0",
+    "cors": "^2.8.4",
+    "express": "^4.15.4",
+    "joi": "^10.6.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^4.1.1",
     "eslint-config-finn": "^2.0.0",
-    "tap": "10.7.2"
+    "tap": "^10.7.2"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "asset-pipe-sink-mem": "1.0.0-beta.5",
     "body": "5.1.0",
     "bole": "3.0.2",
-    "boom": "5.1.0",
-    "compression": "1.6.2",
+    "boom": "5.2.0",
+    "compression": "1.7.0",
     "convict": "4.0.0",
-    "cors": "2.8.3",
-    "express": "4.15.3",
+    "cors": "2.8.4",
+    "express": "4.15.4",
     "joi": "10.6.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^4.1.1",
     "eslint-config-finn": "^2.0.0",
-    "tap": "10.7.0"
+    "tap": "10.7.2"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
This also adds a caret to dependencies. We use lockfiles now (if you're using either npm@5 or yarn, which you should (and we do)), so no need to (try) to lock down dependencies in package.json. As it doesn't recurse, it's false security, and just block updating with bug fixes for consumers