### PR TITLE
fix: handle file download content types

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,7 @@ const CssReader = require('asset-pipe-css-reader');
 const body = require('body/json');
 const boom = require('boom');
 const uuid = require('uuid/v4');
-const extname = require('ext-name');
+const mime = require('mime-types');
 const { Transform } = require('readable-stream');
 
 const params = require('./params');
@@ -56,7 +56,7 @@ module.exports = class Router extends EventEmitter {
 
         this.sink = sink ? sink : new SinkMem();
 
-    this.app = express.Router(); // eslint-disable-line
+        this.app = express.Router(); // eslint-disable-line new-cap
 
         this.app.use((req, res, next) => {
             res.locals.track = uuid();
@@ -284,24 +284,25 @@ module.exports = class Router extends EventEmitter {
         };
     }
 
+    fileFoundCallback(req, res, fileStream) {
+        res.type(mime.lookup(req.params.file) || undefined);
+        fileStream.pipe(res);
+        this.emit(
+            'request success',
+            res.locals.track,
+            req.method,
+            req.path,
+            req.params.file
+        );
+    }
+
     getFileCallback() {
         return (req, res, next) => {
             const fileReadStream = this.sink.reader(req.params.file);
             fileReadStream.on('file not found', this.onFileNotFound(next));
-            fileReadStream.on('file found', () => {
-                const mime =
-                    extname(req.params.file)[0] &&
-                    extname(req.params.file)[0].mime;
-                res.type(mime);
-                fileReadStream.pipe(res);
-                this.emit(
-                    'request success',
-                    res.locals.track,
-                    req.method,
-                    req.path,
-                    req.params.file
-                );
-            });
+            fileReadStream.on('file found', () =>
+                this.fileFoundCallback(req, res, fileReadStream)
+            );
         };
     }
 
@@ -323,8 +324,8 @@ module.exports = class Router extends EventEmitter {
     }
 
     statusErrors() {
-        // eslint-disable-next-line
-    return (error, req, res, next) => {
+        // eslint-disable-next-line no-unused-vars
+        return (error, req, res, next) => {
             const status = error.output.payload.statusCode;
             const message = error.output.payload.error;
             const accepts = req.xhr

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,7 @@ const CssReader = require('asset-pipe-css-reader');
 const body = require('body/json');
 const boom = require('boom');
 const uuid = require('uuid/v4');
-const { extname } = require('path');
+const extname = require('ext-name');
 const { Transform } = require('readable-stream');
 
 const params = require('./params');
@@ -56,7 +56,7 @@ module.exports = class Router extends EventEmitter {
 
         this.sink = sink ? sink : new SinkMem();
 
-        this.app = express.Router(); // eslint-disable-line
+    this.app = express.Router(); // eslint-disable-line
 
         this.app.use((req, res, next) => {
             res.locals.track = uuid();
@@ -289,9 +289,10 @@ module.exports = class Router extends EventEmitter {
             const fileReadStream = this.sink.reader(req.params.file);
             fileReadStream.on('file not found', this.onFileNotFound(next));
             fileReadStream.on('file found', () => {
-                if (extname(req.params.file) === '.json') {
-                    res.type('json');
-                }
+                const mime =
+                    extname(req.params.file)[0] &&
+                    extname(req.params.file)[0].mime;
+                res.type(mime);
                 fileReadStream.pipe(res);
                 this.emit(
                     'request success',
@@ -322,7 +323,8 @@ module.exports = class Router extends EventEmitter {
     }
 
     statusErrors() {
-        return (error, req, res, next) => { // eslint-disable-line
+        // eslint-disable-next-line
+    return (error, req, res, next) => {
             const status = error.output.payload.statusCode;
             const message = error.output.payload.error;
             const accepts = req.xhr

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,7 +316,7 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.2"
+        "readable-stream": "2.3.3"
       }
     },
     "argparse": {
@@ -411,6 +411,22 @@
       "integrity": "sha1-N90Dk6Owb2IU6LHg1lbKGegiyE8=",
       "requires": {
         "readable-stream": "2.3.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        }
       }
     },
     "asset-pipe-css-reader": {
@@ -449,6 +465,22 @@
         "browser-pack": "6.0.2",
         "merge-stream": "1.0.1",
         "readable-stream": "2.3.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        }
       }
     },
     "asset-pipe-sink-fs": {
@@ -459,6 +491,22 @@
         "JSONStream": "1.3.1",
         "asset-pipe-common": "1.0.0-beta.6",
         "readable-stream": "2.3.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        }
       }
     },
     "astral-regex": {
@@ -1517,7 +1565,7 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
     },
@@ -5856,7 +5904,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.3.2"
+        "readable-stream": "2.3.3"
       }
     },
     "methods": {
@@ -6771,9 +6819,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -7604,7 +7652,7 @@
         "methods": "1.1.2",
         "mime": "1.4.1",
         "qs": "6.5.1",
-        "readable-stream": "2.3.2"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "debug": {
@@ -7770,7 +7818,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.2",
+        "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2421,6 +2421,23 @@
         }
       }
     },
+    "ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "requires": {
+        "mime-db": "1.29.0"
+      }
+    },
+    "ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "requires": {
+        "ext-list": "2.2.2",
+        "sort-keys-length": "1.0.1"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -4405,6 +4422,11 @@
         "path-is-inside": "1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -5055,9 +5077,9 @@
       }
     },
     "joi": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.1.tgz",
-      "integrity": "sha512-ChTMfmbIg5yrN9pUdeaLL8vzylMQhUteXiXa1MWINsMUs3jTQ8I87lUZwR5GdfCLJlpK04U7UgrxgmU8Zp7PhQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
+      "integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
       "requires": {
         "hoek": "5.0.0",
         "isemail": "3.0.0",
@@ -7308,6 +7330,22 @@
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "requires": {
+        "sort-keys": "1.1.2"
       }
     },
     "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,23 +2469,6 @@
         }
       }
     },
-    "ext-list": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
-      "requires": {
-        "mime-db": "1.29.0"
-      }
-    },
-    "ext-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
-      "requires": {
-        "ext-list": "2.2.2",
-        "sort-keys-length": "1.0.1"
-      }
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -4469,11 +4452,6 @@
       "requires": {
         "path-is-inside": "1.0.2"
       }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -7378,22 +7356,6 @@
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         }
-      }
-    },
-    "sort-keys": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "sort-keys-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
-      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
-      "requires": {
-        "sort-keys": "1.1.2"
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express": "^4.16.2",
     "ext-name": "^5.0.0",
     "joi": "^13.0.2",
+    "readable-stream": "^2.3.3",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "convict": "^4.0.1",
     "cors": "^2.8.4",
     "express": "^4.16.2",
-    "ext-name": "^5.0.0",
     "joi": "^13.0.2",
     "readable-stream": "^2.3.3",
     "uuid": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "convict": "^4.0.1",
     "cors": "^2.8.4",
     "express": "^4.16.2",
-    "joi": "^13.0.1",
+    "ext-name": "^5.0.0",
+    "joi": "^13.0.2",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -37,7 +37,7 @@ describe('Router class', () => {
     test('new Router().router property', () => {
         expect.assertions(1);
         const router = new Router();
-        expect(router.router.name).toEqual(express.Router().name); // eslint-disable-line
+    expect(router.router.name).toEqual(express.Router().name); // eslint-disable-line
     });
 });
 
@@ -392,8 +392,7 @@ describe('downloading feeds', () => {
             expect(fileName).toBe(`${file}`);
         });
         const { body } = await get(`/feed/${file}`)
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
+            .expect('Content-Type', /application\/json/)
             .expect(200);
 
         expect(body).toMatchSnapshot();
@@ -508,8 +507,9 @@ describe('bundling multiple js feeds', () => {
     });
 
     test('/bundle/:file', async () => {
-        expect.assertions(2);
-        const { text } = await get(`/bundle/${fileName}`).expect(200);
+        expect.assertions(3);
+        const { text, headers } = await get(`/bundle/${fileName}`).expect(200);
+        expect(headers['content-type']).toMatch(/application\/javascript/);
         expect(text).toMatchSnapshot();
     });
 
@@ -629,8 +629,9 @@ describe('bundling multiple css feeds', () => {
     });
 
     test('/bundle/:file', async () => {
-        expect.assertions(2);
-        const { text } = await get(`/bundle/${fileName}`).expect(200);
+        expect.assertions(3);
+        const { text, headers } = await get(`/bundle/${fileName}`).expect(200);
+        expect(headers['content-type']).toMatch(/text\/css/);
         expect(text).toMatchSnapshot();
     });
 


### PR DESCRIPTION
## Status
**READY**

## Description
I had initially intended to proxy the content type from the sink
but in the end I just use the file extension to determine the
Content-Type header to be set as this was how it was already being
done for .json files

Also, weird formatting with the // eslint-disable comment but thats the way
prettier wanted to do it for some reason.

## Todos
- [x] Tests

## Deploy Notes
Should be fine to update only the asset pipe build server itself

## Related PRs
* None