### PR TITLE
fix: make sure all errors are boom errors

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ const express = require('express');
 const SinkMem = require('@asset-pipe/sink-mem');
 const bundleJS = require('@asset-pipe/js-reader');
 const bundleCSS = require('@asset-pipe/css-reader');
-const boom = require('boom');
+const Boom = require('boom');
 const uuid = require('uuid/v4');
 const mime = require('mime-types');
 const { Transform } = require('readable-stream');
@@ -44,7 +44,7 @@ class CheckEmptyPayload extends Transform {
             const msg =
                 'Expected payload provided to `/feed` to be an array ' +
                 `of feed objects but instead payload was unparseable. Got ${buffered}`;
-            return cb(boom.badRequest(msg));
+            return cb(Boom.badRequest(msg));
         }
         if (json.length) {
             for (const chunk of this.chunks) {
@@ -55,7 +55,7 @@ class CheckEmptyPayload extends Transform {
             const msg =
                 'Expected payload provided to `/feed` to be an array ' +
                 `of feed objects but instead got ${buffered}`;
-            cb(boom.badRequest(msg));
+            cb(Boom.badRequest(msg));
         }
     }
 }
@@ -98,6 +98,14 @@ module.exports = class Router extends EventEmitter {
 
         this.app.get('/bundle/:file', this.getFileCallback());
         this.app.get('/test/bundle/:file', this.getTestFileCallback());
+
+        this.app.use((err, req, res, next) => {
+            if (Boom.isBoom(err)) {
+                next(err);
+            } else {
+                next(Boom.boomify(err));
+            }
+        });
 
         this.app.use((error, req, res, next) => {
             this.emit(
@@ -181,7 +189,7 @@ module.exports = class Router extends EventEmitter {
                 feedIds = result.value;
             } catch (e) {
                 return next(
-                    boom.boomify(e, {
+                    Boom.boomify(e, {
                         statusCode: 400,
                         message: 'Invalid POST-body',
                     })
@@ -205,7 +213,7 @@ module.exports = class Router extends EventEmitter {
             } catch (e) {
                 if (e.message.includes('No file with name')) {
                     return next(
-                        boom.boomify(e, {
+                        Boom.boomify(e, {
                             statusCode: 409,
                         })
                     );
@@ -256,20 +264,20 @@ module.exports = class Router extends EventEmitter {
 
     onError(next, message) {
         return error => {
-            next(boom.boomify(error, { statusCode: 400, message }));
+            next(Boom.boomify(error, { statusCode: 400, message }));
         };
     }
 
     onFileNotFound(next) {
         return () => {
-            next(boom.notFound());
+            next(Boom.notFound());
         };
     }
 
     onPipelineEmpty(next) {
         return () => {
             next(
-                boom.badRequest(
+                Boom.badRequest(
                     'Could not load 1 or more of the resources in the payload from storage'
                 )
             );

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,3 +1,0 @@
-'use strict';
-
-test('it works');


### PR DESCRIPTION
## JIRA Issue
[COREWEB-107](COREWEB-107)

## Status
**READY**

## Description
If something throws,  those errors are not wrapped in boom, making the error handler itself throw. This middleware ensures that all errors are boom errors in the error handler.

These lines assume all errors are `Boom`s: https://github.com/asset-pipe/asset-pipe-build-server/blob/85c8312017ee4cea483c84fc8ab2dbd7ab0218bd/lib/main.js#L321-L322

## Todos
- [x] Tests
- [ ] Documentation - N/A

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* None