### PR TITLE
COREWEB-41 - Offload bundling

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const bundleJS = require('@asset-pipe/js-reader');
+const bundleCSS = require('@asset-pipe/css-reader');
+
+module.exports.bundeJS = bundleJS;
+module.exports.bundeCSS = bundleCSS;

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,12 @@ const mime = require('mime-types');
 const { Transform } = require('readable-stream');
 const params = require('./params');
 const assert = require('assert');
-const { parseBody, validateFeeds, bundleAndUpload } = require('./utils');
+const {
+    parseBody,
+    validateFeeds,
+    bundleAndUpload,
+    endWorkers,
+} = require('./utils');
 
 class CheckEmptyPayload extends Transform {
     constructor() {
@@ -293,5 +298,10 @@ module.exports = class Router extends EventEmitter {
                     res.status(406).send('Not Acceptable');
             }
         };
+    }
+
+    /* istanbul ignore next: invoking this method in the test has repercussions */
+    async cleanup() {
+        endWorkers();
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,6 @@ function validateFeeds(feeds) {
     return result.value;
 }
 
-// Should be exposed for graceful shutdowns
 function endWorkers() {
     bundleWorker.end();
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,13 +2,14 @@
 
 const assert = require('assert');
 const Boom = require('boom');
-const bundleJS = require('@asset-pipe/js-reader');
-const bundleCSS = require('@asset-pipe/css-reader');
 const { promisify } = require('util');
 const body = promisify(require('body/json'));
 const schemas = require('./schemas');
 const parseJson = require('parse-json');
 const { hasher } = require('asset-pipe-common');
+const { default: Worker } = require('jest-worker');
+
+const bundleWorker = new Worker(require.resolve('./bundler'));
 
 async function fetchFeeds(sink, ids) {
     try {
@@ -42,7 +43,7 @@ function parseFeedContent(feeds) {
 async function bundleFeeds(feeds, type) {
     if (type === 'css') {
         try {
-            return await bundleCSS(feeds);
+            return await bundleWorker.bundeCSS(feeds);
         } catch (err) {
             throw Boom.boomify(err, {
                 message: 'Unable to bundle feeds as CSS.',
@@ -50,7 +51,7 @@ async function bundleFeeds(feeds, type) {
         }
     } else {
         try {
-            return await bundleJS(feeds);
+            return await bundleWorker.bundeJS(feeds);
         } catch (err) {
             throw Boom.boomify(err, {
                 message: 'Unable to bundle feeds as JS.',
@@ -110,7 +111,13 @@ function validateFeeds(feeds) {
     return result.value;
 }
 
+// Should be exposed for graceful shutdowns
+function endWorkers() {
+    bundleWorker.end();
+}
+
 module.exports = {
+    endWorkers,
     fetchFeeds,
     parseFeedContent,
     bundleFeeds,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4869,9 +4869,9 @@
       }
     },
     "jest-worker": {
-      "version": "21.3.0-beta.14",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.14.tgz",
-      "integrity": "sha512-TTWrAVYoDr7bhgTB/lpySRb8znMhzEbTUHsLAmGUNJfmPIoW4pfQLBOOSBbl+qlBkQRnoMk3JlJ0+F3gkY+T6Q==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.0.0.tgz",
+      "integrity": "sha512-s3pa1SDAYmIxH7IUmP5OFVl8cw4VULsuESk3DUloatE71iFmUjtnLxtY9ps1C+Dg3b/dJuDOn7i0qKiMKBX7bQ==",
       "requires": {
         "merge-stream": "1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,9 +1982,9 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "errno": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz",
-      "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
         "prr": "1.0.1"
@@ -4868,6 +4868,14 @@
         }
       }
     },
+    "jest-worker": {
+      "version": "21.3.0-beta.14",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.14.tgz",
+      "integrity": "sha512-TTWrAVYoDr7bhgTB/lpySRb8znMhzEbTUHsLAmGUNJfmPIoW4pfQLBOOSBbl+qlBkQRnoMk3JlJ0+F3gkY+T6Q==",
+      "requires": {
+        "merge-stream": "1.0.1"
+      }
+    },
     "joi": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
@@ -5697,6 +5705,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -8370,7 +8386,7 @@
       "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.5",
+        "errno": "0.1.6",
         "xtend": "4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "convict": "^4.0.1",
     "cors": "^2.8.4",
     "express": "^4.16.2",
-    "jest-worker": "^21.3.0-beta.14",
+    "jest-worker": "^22.0.0",
     "joi": "^13.0.2",
     "mime-types": "^2.1.17",
     "p-retry": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "convict": "^4.0.1",
     "cors": "^2.8.4",
     "express": "^4.16.2",
+    "jest-worker": "^21.3.0-beta.14",
     "joi": "^13.0.2",
     "mime-types": "^2.1.17",
     "p-retry": "^1.0.0",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -302,6 +302,13 @@ describe('Router instance methods', () => {
 
         expect(uri).toBe('http://foo/bar/');
     });
+
+    test('cleanup', () => {
+        const router = new Router();
+
+        // Actually invoking it messes up all other tests...
+        expect(router.cleanup).toBeInstanceOf(Function);
+    });
 });
 
 describe('uploading js feeds', () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -7,6 +7,7 @@ const Router = require('../lib/main');
 const supertest = require('supertest');
 const pretty = require('pretty');
 const { PassThrough } = require('readable-stream');
+const { endWorkers } = require('../lib/utils');
 
 function createTestServerFor(router) {
     const app = express();
@@ -20,6 +21,8 @@ function createTestServerFor(router) {
         });
     });
 }
+
+afterAll(() => endWorkers());
 
 describe('Router class', () => {
     test('new Router() with no arguments', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -7,7 +7,7 @@ test('bundleFeeds() throws error when bundling JS', async () => {
     jest.doMock('@asset-pipe/js-reader', () => () =>
         Promise.reject(new Error())
     );
-    const { bundleFeeds } = require('../lib/utils');
+    const { bundleFeeds, endWorkers } = require('../lib/utils');
 
     try {
         await bundleFeeds(
@@ -16,6 +16,8 @@ test('bundleFeeds() throws error when bundling JS', async () => {
         );
     } catch (err) {
         expect(err.message).toMatch(/Unable to bundle feeds as JS/);
+    } finally {
+        endWorkers();
     }
 });
 
@@ -24,7 +26,7 @@ test('bundleFeeds() throws error when bundling CSS', async () => {
     jest.doMock('@asset-pipe/css-reader', () => () =>
         Promise.reject(new Error())
     );
-    const { bundleFeeds } = require('../lib/utils');
+    const { bundleFeeds, endWorkers } = require('../lib/utils');
 
     try {
         await bundleFeeds(
@@ -33,12 +35,14 @@ test('bundleFeeds() throws error when bundling CSS', async () => {
         );
     } catch (err) {
         expect(err.message).toMatch(/Unable to bundle feeds as CSS/);
+    } finally {
+        endWorkers();
     }
 });
 
 test('upload() handles errors correctly', async () => {
     expect.hasAssertions();
-    const { upload } = require('../lib/utils');
+    const { upload, endWorkers } = require('../lib/utils');
     const sinkStub = {
         async set() {
             throw new Error('Upload failed');
@@ -51,5 +55,7 @@ test('upload() handles errors correctly', async () => {
         expect(err.message).toMatch(
             /Unable to upload file with name "filename.js"/
         );
+    } finally {
+        endWorkers();
     }
 });


### PR DESCRIPTION
## JIRA Issue
[COREWEB-41](https://jira.finn.no/browse/COREWEB-41)

## Status
**READY**

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
We want to offload bundling to another thread/process to not lock up resources on potentially CPU heavy work.

As we use promises, `worker-farm` is not an option (it only supports callbacks), so I chose to go with `jest-worker`, which is what runs Jest tests in parallel.

I have not added new tests, as the observable behaviour is identical, beyond some extra needed cleanup work. We don't have programmatic API documented in the README, perhaps we should?

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->
N/A

## Related PRs
* None