### PR TITLE
feat(metadata): add new endpoints persisiting metadata

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@ const uuid = require('uuid/v4');
 const mime = require('mime-types');
 const { Transform } = require('readable-stream');
 const params = require('./params');
+const MetaStorage = require('./meta-storage');
 const {
     parseBody,
     validateFeeds,
@@ -57,6 +58,7 @@ module.exports = class Router extends EventEmitter {
         super();
 
         this.sink = sink ? sink : new SinkMem();
+        this.metaStorage = new MetaStorage(this.sink);
 
         this.app = express.Router(); // eslint-disable-line new-cap
 
@@ -70,14 +72,14 @@ module.exports = class Router extends EventEmitter {
         this.app.param('type', params.type);
 
         this.app.post(
-            '/feed/:type',
+            '/feed/:type/:id?',
             this.postFeedPersistCallback(),
             this.postFeedResponseCallback()
         );
 
         this.app.get('/feed/:file', this.getFileCallback());
 
-        this.app.post('/bundle/:type', this.postBundleHandler());
+        this.app.post('/bundle/:type/:id?', this.postBundleHandler());
 
         this.app.get('/bundle/:file', this.getFileCallback());
         this.app.get('/test/bundle/:file', this.getTestFileCallback());
@@ -143,7 +145,22 @@ module.exports = class Router extends EventEmitter {
     }
 
     postFeedResponseCallback() {
-        return (req, res) => {
+        return async (req, res, next) => {
+            const { id, type } = req.params;
+
+            if (id) {
+                const filename = `${type}/${id}`;
+
+                try {
+                    await this.metaStorage.set(filename, {
+                        id,
+                        version: res.locals.response.file,
+                    });
+                } catch (e) {
+                    return next(e);
+                }
+            }
+
             res.json(res.locals.response);
             this.emit(
                 'request success',
@@ -157,6 +174,8 @@ module.exports = class Router extends EventEmitter {
 
     postBundleHandler() {
         return async (req, res, next) => {
+            const { id, type } = req.params;
+
             try {
                 this.emit('info', `Parsing raw feed data from body`);
                 const payload = await parseBody(req, res);
@@ -178,12 +197,21 @@ module.exports = class Router extends EventEmitter {
                     sink: this.sink,
                     feedIds,
                     uri: this.buildUri('bundle', req.headers.host, req.secure),
-                    type: req.params.type,
+                    type,
                 });
                 this.emit(
                     'info',
                     `Requested asset bundle produced and successfully uploaded.`
                 );
+
+                if (id) {
+                    const filename = `${type}/${id}`;
+
+                    await this.metaStorage.set(filename, {
+                        id,
+                        version: response.file,
+                    });
+                }
 
                 this.emit(
                     'request success',

--- a/test/__snapshots__/main.test.js.snap
+++ b/test/__snapshots__/main.test.js.snap
@@ -106,10 +106,38 @@ Object {
 }
 `;
 
+exports[`bundling single css feed persist meta information 1`] = `
+[MockFunction metaStorageSet] {
+  "calls": Array [
+    Array [
+      "css/myId",
+      Object {
+        "id": "myId",
+        "version": "28b015efa819a445a46282fff9125aac41deed83d81d5f19a994a322f30cbbfb.css",
+      },
+    ],
+  ],
+}
+`;
+
 exports[`bundling single js feed /bundle/js 1`] = `
 Object {
   "file": "0b8699357bf3807af4ed0e91c1e8bbc5ae86c2fafa6a2b3c3444950457d034fd.js",
   "uri": "/bundle/0b8699357bf3807af4ed0e91c1e8bbc5ae86c2fafa6a2b3c3444950457d034fd.js",
+}
+`;
+
+exports[`bundling single js feed persist meta information 1`] = `
+[MockFunction metaStorageSet] {
+  "calls": Array [
+    Array [
+      "js/myId",
+      Object {
+        "id": "myId",
+        "version": "0b8699357bf3807af4ed0e91c1e8bbc5ae86c2fafa6a2b3c3444950457d034fd.js",
+      },
+    ],
+  ],
 }
 `;
 
@@ -122,4 +150,32 @@ Array [
     "source": "\\"use strict\\";module.exports.world=function(){return\\"world\\"};",
   },
 ]
+`;
+
+exports[`uploading css feeds /feed/css/myId 1`] = `
+[MockFunction metaStorageSet] {
+  "calls": Array [
+    Array [
+      "css/myId",
+      Object {
+        "id": "myId",
+        "version": "3252bd07a7cbf1c6be20e197ef81070673d00ee887ebf1e3ca60582f44e37617.json",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`uploading js feeds /feed/js/myId 1`] = `
+[MockFunction metaStorageSet] {
+  "calls": Array [
+    Array [
+      "js/myId",
+      Object {
+        "id": "myId",
+        "version": "f652e904f72daa8bd884df867b69861bcb90be9508a1d558f05070d5d044d0d3.json",
+      },
+    ],
+  ],
+}
 `;


### PR DESCRIPTION
## JIRA Issue
[COREWEB-122](https://jira.finn.no/browse/COREWEB-122)

## Status
**READY**

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This adds new endpoints with `id` in them. The data persisted is not what we want in the end, but that can be fixed in another task.

The endpoint will allow us to collect data about which podlets are in use in which layout servers, and vice versa.

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* None