### PR TITLE
feat: add sync method and public asset url

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,21 @@ You can then download the bundle from `/bundle/:hash`
 
 The server provides the following endpoints:
 
-| Verb | Endpoint              | Description                                                                      | url params   | query params    | payload                | response          |
-| ---- | --------------------- | -------------------------------------------------------------------------------- | ------------ | --------------- | ---------------------- | ----------------- |
-| POST | /feed/js              | Upload a javascript asset feed                                                   | -            | -               | `js feed`              | `feed response`   |
-| POST | /feed/js/:id          | Upload a javascript asset feed and persist metadata to build server              | `identifier` | -               | `js feed`              | `feed response`   |
-| POST | /feed/css             | Upload a css asset feed                                                          | -            | -               | `css feed`             | `feed response`   |
-| POST | /feed/css/:id         | Upload a css asset feed and persist metadata to build server                     | `identifier` | -               | `css feed`             | `feed response`   |
-| GET  | /feed/:id             | Download an asset feed                                                           | `feed id`    | -               | -                      | `feed`            |
-| POST | /bundle/js            | Request bundling of a list of js feeds                                           | -            | minify: `false` | `js bundle`            | `bundle response` |
-| POST | /bundle/js/:id        | Request bundling of a list of js feeds and persist metadata to build server      | `identifier` | minify: `false` | `js bundle`            | `bundle response` |
-| POST | /bundle/css           | Request bundling of a list of css feeds                                          | -            | -               | `css bundle`           | `bundle response` |
-| POST | /bundle/css/:id       | Request bundling of a list of css feeds and persist metadata to build server     | `identifier` | -               | `css bundle`           | `bundle response` |
-| GET  | /bundle/:id           | Download an asset bundle                                                         | `bundle id`  | -               | -                      | `bundle`          |
-| POST | /publish-assets       | Publish an asset feed in an "optimistic bundling" compatible way.                | -            | -               | `asset definition`     | `feed response`   |
-| POST | /publish-instructions | Publish an asset bundling instruction to begin "optimistically bundling" assets. | -            | -               | `bundling instruction` | `{success: true}` |
+| Verb | Endpoint              | Description                                                                                  | url params   | query params    | payload                | response                                   |
+| ---- | --------------------- | -------------------------------------------------------------------------------------------- | ------------ | --------------- | ---------------------- | ------------------------------------------ |
+| POST | /feed/js              | Upload a javascript asset feed                                                               | -            | -               | `js feed`              | `feed response`                            |
+| POST | /feed/js/:id          | Upload a javascript asset feed and persist metadata to build server                          | `identifier` | -               | `js feed`              | `feed response`                            |
+| POST | /feed/css             | Upload a css asset feed                                                                      | -            | -               | `css feed`             | `feed response`                            |
+| POST | /feed/css/:id         | Upload a css asset feed and persist metadata to build server                                 | `identifier` | -               | `css feed`             | `feed response`                            |
+| GET  | /feed/:id             | Download an asset feed                                                                       | `feed id`    | -               | -                      | `feed`                                     |
+| POST | /bundle/js            | Request bundling of a list of js feeds                                                       | -            | minify: `false` | `js bundle`            | `bundle response`                          |
+| POST | /bundle/js/:id        | Request bundling of a list of js feeds and persist metadata to build server                  | `identifier` | minify: `false` | `js bundle`            | `bundle response`                          |
+| POST | /bundle/css           | Request bundling of a list of css feeds                                                      | -            | -               | `css bundle`           | `bundle response`                          |
+| POST | /bundle/css/:id       | Request bundling of a list of css feeds and persist metadata to build server                 | `identifier` | -               | `css bundle`           | `bundle response`                          |
+| GET  | /bundle/:id           | Download an asset bundle                                                                     | `bundle id`  | -               | -                      | `bundle`                                   |
+| POST | /publish-assets       | Publish an asset feed in an "optimistic bundling" compatible way.                            | -            | -               | `asset definition`     | `feed response`                            |
+| POST | /publish-instructions | Publish an asset bundling instruction to begin "optimistically bundling" assets.             | -            | -               | `bundling instruction` | `{success: true}`                          |
+| GET  | /sync                 | Retrieve centralized server configuration information. Currently only public asset locations | -            | -               | -                      | `{publicBundleUrl: '', publicFeedUrl: ''}` |
 
 See below for explanation and additional detail regarding the various url params, payloads and responses.
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -117,6 +117,7 @@ module.exports = class Router extends EventEmitter {
         this.options = {
             logger: emitLogger(this),
             env: NODE_ENV || DEFAULT_NODE_ENV,
+            publicAssetUrl: null,
             ...options,
         };
         this.options.isProduction = this.options.env === 'production';
@@ -168,6 +169,17 @@ module.exports = class Router extends EventEmitter {
             } catch (err) {
                 next(err);
             }
+        });
+
+        this.app.get('/sync', async (req, res) => {
+            res.json({
+                publicBundleUrl:
+                    this.options.publicAssetUrl ||
+                    this.buildUri('bundle', req.headers.host, req.secure),
+                publicFeedUrl:
+                    this.options.publicAssetUrl ||
+                    this.buildUri('feed', req.headers.host, req.secure),
+            });
         });
 
         this.app.post('/publish-instructions', async (req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asset-pipe/common": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@asset-pipe/common/-/common-2.0.0.tgz",
-      "integrity": "sha512-9ajcAlzfusBodEwRPhmvmKvh7okWGnybr8Yek9j6FW2Ek7TVKABpBM1KYSrXCYfDJzolN11+9Hxpe8o3YViBvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asset-pipe/common/-/common-3.0.0.tgz",
+      "integrity": "sha512-G0thyyIF0oJWw1TxUukY+gsIj5xC25wmTcrUww3347lH6OlXlvTM8gZk36YOgf8ekEyvetu0pe7D2DBvx7KRXw==",
       "requires": {
         "readable-stream": "2.3.3"
       },
@@ -9552,7 +9552,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -832,3 +832,31 @@ test('options - env defaults to process.env.NODE_ENV when process.env.NODE_ENV s
     process.env.NODE_ENV = env;
     expect(router.options.env).toBe('production');
 });
+
+test('options - sync method', async () => {
+    const router = new Router();
+    const { server } = await createTestServerFor(router.router());
+    const { get } = supertest(server);
+
+    const { body } = await get('/sync');
+
+    expect(body.publicBundleUrl).toMatch(/https?:\/\/[0-9.]+:[0-9]+\/bundle/);
+    expect(body.publicFeedUrl).toMatch(/https?:\/\/[0-9.]+:[0-9]+\/feed/);
+    await server.close();
+});
+
+test('options - sync method with publicAssetUrl set', async () => {
+    const router = new Router(null, {
+        publicAssetUrl: 'http://my-cdn-url',
+    });
+    const { server } = await createTestServerFor(router.router());
+    const { get } = supertest(server);
+
+    const { body } = await get('/sync');
+
+    expect(body).toEqual({
+        publicBundleUrl: 'http://my-cdn-url',
+        publicFeedUrl: 'http://my-cdn-url',
+    });
+    await server.close();
+});


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
Adds a sync endpoint to the server as a way for the server to centralise information that can be acquired by clients. For now the only use case for this is the public asset locations.

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Asset clients need to be updated to make use of new server functionality. Client PR 56 needs to be landed before this can happen. See Related PRs.

## Related PRs
* https://github.com/asset-pipe/asset-pipe-client/pull/56