### PR TITLE
fix: ensure any errors are handled in /bundle

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -386,11 +386,21 @@ module.exports = class Router extends EventEmitter {
 
     getFileCallback() {
         return (req, res, next) => {
-            const fileReadStream = this.sink.reader(req.params.file);
-            fileReadStream.on('file not found', this.onFileNotFound(next));
-            fileReadStream.on('file found', () =>
-                this.fileFoundCallback(req, res, fileReadStream)
-            );
+            const file = req.params.file;
+            try {
+                const fileReadStream = this.sink.reader(file);
+                fileReadStream.on('error', next);
+                fileReadStream.on('file not found', this.onFileNotFound(next));
+                fileReadStream.on('file found', () =>
+                    this.fileFoundCallback(req, res, fileReadStream)
+                );
+            } catch (err) {
+                next(
+                    Boom.boomify(err, {
+                        message: `Attempting to read the file (${file}) caused an unknown error. This likely means that the underlying stream mechanism failed in an unexpected way when trying to read the file and this could not be handled.`,
+                    })
+                );
+            }
         };
     }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -860,3 +860,15 @@ test('options - sync method with publicAssetUrl set', async () => {
     });
     await server.close();
 });
+
+test('Sink reader error handled', async () => {
+    const router = new Router();
+    const { server } = await createTestServerFor(router.router());
+    const { get } = supertest(server);
+    router.sink.reader = () => {
+        throw new Error('Exploding reader!!');
+    };
+    await get('/bundle/fake.js').expect(500);
+
+    await server.close();
+});


### PR DESCRIPTION
## Status
**READY**

## Description
Adds additional error handling around file fetch code so that if the underlying stream blows up then it does not bring down the server.

## Todos
- [x] Tests
