### PR TITLE
fix: update to latest js-reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@asset-pipe/common": "3.0.1",
     "@asset-pipe/css-reader": "1.1.1",
-    "@asset-pipe/js-reader": "2.3.3",
+    "@asset-pipe/js-reader": "^2.3.4",
     "@asset-pipe/sink-fs": "1.1.4",
     "@asset-pipe/sink-mem": "1.1.3",
     "@metrics/client": "2.1.1",


### PR DESCRIPTION
## Status
**READY**

## Description
Updates to latest js-reader so that browserify can be configured to support typescript transforms/plugins.