### PR TITLE
fix: pass options to css reader

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -54,7 +54,7 @@ module.exports = class Bundler {
     async bundleFeeds(feeds, type, options) {
         if (type === 'css') {
             try {
-                return await this.bundler.bundleCSS(feeds);
+                return await this.bundler.bundleCSS(feeds, options);
             } catch (err) {
                 throw Boom.boomify(err, {
                     message: 'Unable to bundle feeds as CSS.',


### PR DESCRIPTION
This is related to enabling [cssnano](https://cssnano.co/) on [css-reader](https://github.com/asset-pipe/asset-pipe-css-reader) (that isn't out yet, but this small change is safe to apply meanwhile) to dedupe CSS and remove prefixes that are no longer needed according to the browserslist config.